### PR TITLE
Load agents v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,7 @@ venv.bak/
 # Exclude model files
 *.gz
 *.cleanrl_model
-models
+*.cleanrl
 
 #Plots
 scripts/Plots

--- a/models/models.md
+++ b/models/models.md
@@ -1,0 +1,69 @@
+# Usage of Trained Agents
+
+This guide explains how to use the pre-trained agents for Atari games using OCAtari. The models must be downloaded and can be used with the provided script from the script folder.
+
+---
+
+## **1. Downloading the Models**
+
+The trained models can be downloaded from the following link:
+
+[Download Models](https://hessenbox.tu-darmstadt.de/getlink/fiMp3RajkfxCvHXY8zFGC8VW/)
+
+Ensure that the downloaded models are placed in the appropriate directory, such as `OCAtari/models/` or another path of your choosing.
+
+---
+
+## **2. Running the Agents**
+
+Use the `scripts/run_agent.py` script to evaluate the pre-trained agents. The script supports specifying the game, model, and configuration options.
+
+### **Command Structure**
+```bash
+python scripts/run_agent.py -g <GAME_NAME> -a <MODEL_PATH> -w <WINDOW_SIZE> -f <FRAMESKIP> -o <OBS_MODE>
+```
+- **`<GAME_NAME>`**: Name of the Atari game (e.g., `Skiing-v4`, `Freeway`, `ALE/Freeway`, `ALE/Skiing-v5`, ...). The `ALE` in front of the name specifies the newer v5 version.
+- **`<MODEL_PATH>`**: Path to the trained model file
+- **`<WORKERS>`**: Number of images in the stack (Default is 2 for obj and 4 for dqn-like)
+- **`<FRAMESKIP>`**: Number of frames to skip (Default in v5 is 4)
+- **`<ALGORITHM>`**: Observation mode (`dqn` or `obj`)
+
+### **Example Commands**
+
+#### 2. Running PPO on ALE/Freeway
+```bash
+python scripts/run_agent.py -g ALE/Freeway -a models/Freeway/42/pixel_ppo.cleanrl_model -w 4 -f 4 -o dqn
+```
+
+#### 4. Running Object-Centric PPO on Skiing
+```bash
+python scripts/run_agent.py -g ALE/Skiing -a models/Skiing/42/obj_ppo.cleanrl_model -w 2 -f 4 -o obj
+```
+
+---
+
+## ** 3. Use your own models with OCAtari**
+* Check out the `run_agent` script and replace the `load_agent` method with your own agent definition
+* Set the parameters to match your model training environment (frameskip, window_size, model)
+* Replace the policy with your predict method or a like
+
+
+## **4. Notes**
+- Ensure all dependencies are installed (e.g., `gymnasium`, `ale-py`, `torch`).
+- Verify the model paths are correct relative to your script.
+- For headless environments, consider using virtual display tools like `Xvfb`.
+- More config settings can be found in the script itself, e.g., if you want to record a video of a run.
+
+---
+
+## **5. Troubleshooting**
+
+### **Issue: `Missing ROMS`**
+* Check if you install gymnasium with the correct parameters `pip install "gymnasium[atari, accept-rom-license]"`
+
+### **Misshape in the neural network**
+* Check that you used the correct parameters (-w, -f, -o) for the model you want to use
+
+---
+
+For further assistance, please reach out to the maintainers or consult the project documentation.

--- a/ocatari/utils.py
+++ b/ocatari/utils.py
@@ -11,6 +11,7 @@ import select
 import time
 import atexit
 import pygame
+from functools import partial
 
 try:
     import torch
@@ -196,10 +197,6 @@ if torch_imported:
                 return torch.mul(qs_probs, self.__support.expand_as(qs_probs)).sum(2)
             return qs
 
-        def draw_action(self, state):
-            probs = self.forward(state)
-            return probs.argmax()
-
     class RandomAgent():
         """
         A agent acting randomly (following a uniform distribution).
@@ -221,15 +218,22 @@ def _load_checkpoint(fpath, device="cpu"):
             return torch.load(inflated, map_location=device)
 
 
+def _epsilon_greedy(model, obs, eps=0.001):
+    if torch.rand((1,)).item() < eps:
+        return torch.randint(model.action_no, (1,)).item(), None
+    obs = obs.byte()
+    q_val, argmax_a = model(obs).max(1)
+    return argmax_a.item(), q_val
+
+
 def load_agent(opt, nb_actions=None, env=None, device="cpu"):
     pth = opt if isinstance(opt, str) else opt.path
     if "dqn" in pth or "c51" in pth:
-        pth = pth.replace("ALE/", "")
-        pth = pth.replace("Deterministic", "").replace("NoFrameskip", "")
-        pth = pth.replace("-v0", "").replace("-v4", "")
         agent = AtariNet(nb_actions, distributional="c51" in pth)
         ckpt = _load_checkpoint(pth)
         agent.load_state_dict(ckpt['estimator_state'])
+        policy = partial(_epsilon_greedy, agent, eps=0.001)
+        return agent, policy
     elif "cleanrl" in pth:
         ckpt = torch.load(pth)
         if "c51" in pth:
@@ -245,7 +249,9 @@ def load_agent(opt, nb_actions=None, env=None, device="cpu"):
         else:
             return None
 
-    return agent
+        policy = agent.draw_action
+
+    return agent, policy
 
 
 def draw_arrow(surface: pygame.Surface, start_pos: (float, float), end_pos: (float, float),

--- a/ocatari/utils.py
+++ b/ocatari/utils.py
@@ -226,10 +226,10 @@ def _epsilon_greedy(model, obs, eps=0.001):
     return argmax_a.item(), q_val
 
 
-def load_agent(opt, nb_actions=None, env=None, device="cpu"):
+def load_agent(opt, env=None, device="cpu"):
     pth = opt if isinstance(opt, str) else opt.path
     if "dqn" in pth or "c51" in pth:
-        agent = AtariNet(nb_actions, distributional="c51" in pth)
+        agent = AtariNet(env.action_space.n, distributional="c51" in pth)
         ckpt = _load_checkpoint(pth)
         agent.load_state_dict(ckpt['estimator_state'])
         policy = partial(_epsilon_greedy, agent, eps=0.001)
@@ -237,7 +237,7 @@ def load_agent(opt, nb_actions=None, env=None, device="cpu"):
     elif "cleanrl" in pth:
         ckpt = torch.load(pth)
         if "c51" in pth:
-            agent = QNetwork(nb_actions)
+            agent = QNetwork(env.action_space.n)
             agent.load_state_dict(ckpt["model_weights"])
         elif "ppo" in pth and env.obs_mode == "dqn":
             agent = PPOAgent(env)

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -23,6 +23,30 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "-o",
+    "--obs_mode",
+    type=str,
+    default="obj",
+    help="The observation mode (ori, dqn, obj)",
+)
+
+parser.add_argument(
+    "-w",
+    "--window",
+    type=int,
+    default=4,
+    help="The buffer window size (default = 4)",
+)
+
+parser.add_argument(
+    "-f",
+    "--frameskip",
+    type=int,
+    default=4,
+    help="The frames skipped after each action + 1 (default = 4)",
+)
+
+parser.add_argument(
     "-m",
     "--movie",
     type=bool,
@@ -35,12 +59,12 @@ args = parser.parse_args()
 env = OCAtari(
     args.game,
     render_mode="rgb_array" if args.movie else "human",
-    obs_mode="obj",
+    obs_mode=args.obs_mode,
     mode="ram",
     hud=False,
     render_oc_overlay=True,
-    buffer_window_size=2,
-    frameskip=4,
+    buffer_window_size=args.window,
+    frameskip=args.frameskip,
 )
 
 if args.movie:
@@ -49,7 +73,7 @@ if args.movie:
 pygame.init()
 if args.agent:
     # agent = load_agent("../OC_Atari/models/Skiing/obj_based_ppo.cleanrl_model", env.action_space.n, env)
-    agent = load_agent(args.agent, env.action_space.n, env, "cpu")
+    agent, policy = load_agent(args.agent, env.action_space.n, env, "cpu")
     print(f"Loaded agents from {args.agent}")
 
 obs, _ = env.reset()
@@ -66,8 +90,7 @@ while not done:
             done = True
     if args.agent:
         dqn_obs = torch.Tensor(obs).unsqueeze(0)
-        action, _, _, _ = agent.get_action_and_value(dqn_obs)
-        action = action[0]
+        action = policy(dqn_obs)[0]
     else:
         action = env.action_space.sample()
     # import ipdb; ipdb.set_trace()

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -73,7 +73,7 @@ if args.movie:
 pygame.init()
 if args.agent:
     # agent = load_agent("../OC_Atari/models/Skiing/obj_based_ppo.cleanrl_model", env.action_space.n, env)
-    agent, policy = load_agent(args.agent, env.action_space.n, env, "cpu")
+    agent, policy = load_agent(args.agent, env, "cpu")
     print(f"Loaded agents from {args.agent}")
 
 obs, _ = env.reset()

--- a/tests/2_models/test_models.py
+++ b/tests/2_models/test_models.py
@@ -1,0 +1,66 @@
+import pytest
+import numpy as np
+import os
+import pickle as pkl
+from ocatari.core import OCAtari, AVAILABLE_GAMES
+from ocatari.utils import load_agent
+import torch
+
+# Get GAMES from the environment variable or use default if not set
+
+GAMES = ["ALE/Skiing"]
+
+MODLE_PATH = f"models/Skiing/obj_based_ppo.cleanrl_model"
+
+MODES = ["ram", ]
+OBS_MODES = ["obj"]
+FRAMESKIPS = [1, 4]
+
+
+def load_model(env, game_name, model_path):
+    """
+    Load the model from the path.
+    """
+    return load_agent(model_path, env, "cpu")
+
+
+@pytest.mark.parametrize("env_name, mode, obs_mode", [(game, mode, obs_mode) for game in GAMES for mode in MODES for obs_mode in OBS_MODES])
+def test_environment_initialization(env_name, mode, obs_mode):
+    """
+    Test the OCAtari environment initialization with different modes.
+    """
+
+    env = OCAtari(env_name=env_name, mode=mode, obs_mode=obs_mode,
+                  frameskip=4, buffer_window_size=2)
+    assert env is not None, f"Failed to initialize OCAtari environment: {env_name}"
+    assert env.env_name == env_name or env.env_name == f"ALE/{env_name}-v5" or env.env_name == f"ALE/{env_name}", "Environment name does not match."
+    assert env.mode == mode, "Mode does not match expected."
+    agent, policy = load_model(env, env.game_name, MODLE_PATH)
+    assert agent is not None
+    assert policy is not None
+    env.close()
+
+
+@pytest.mark.parametrize("env_name, mode, obs_mode, frameskip", [(game, mode, obs_mode, frameskip) for game in GAMES for mode in MODES for obs_mode in OBS_MODES for frameskip in FRAMESKIPS])
+def test_environment_step(env_name, mode, obs_mode, frameskip):
+    """
+    Test stepping through the environment.
+    """
+    env = OCAtari(env_name=env_name, mode=mode,
+                  obs_mode=obs_mode, frameskip=frameskip, buffer_window_size=2)
+    agent, policy = load_model(env, env.game_name, MODLE_PATH)
+    env.reset()
+    obs, reward, truncated, terminated, info = env.step(0)
+    # Execute a random action (e.g., action 0)
+    assert obs is not None, "Observation should not be None after taking a step."
+    assert isinstance(reward, (int, float)), "Reward should be a number."
+    assert isinstance(truncated, bool), "Truncated should be a boolean value."
+    assert isinstance(
+        terminated, bool), "Terminated should be a boolean value."
+    assert isinstance(info, dict), "Info should be a dictionary."
+
+    dqn_obs = torch.Tensor(obs).unsqueeze(0)
+    action = policy(dqn_obs)[0]
+    assert action is (int, float)
+    obs, reward, truncated, terminated, info = env.step(action)
+    env.close()


### PR DESCRIPTION
# Loading_agents_v2
---

### Description  
Updated the loading function for models, so that it supports the newest models from floringogianu (https://github.com/floringogianu/atari-agents/blob/main)

- **What was added/changed**:  
  - load_agents now returns the agent itself as well as a policy function which is used to get an action from a state observation (in form of a buffer)
  - Updated run_agent. script so it uses the new load_agent method
- **Why this is necessary**:  
  - Different model implementations are using different methods to call for prediction (draw_action, predict, forward, ...)

---

### Issue(s)  
* No open issues solved, its an quality fix

---

### Type of Change  
<!-- Please select the type that best describes this PR. -->

- [ ] 🐛 Bug fix  
- [ ] ✨ New feature  
- [ ] 🚨 Breaking change  
- [ ] 🛠 Refactor  
- [ ] 📪 Tests  
- [ ] 📝 Documentation update
- [x] ✨Enhancement  
- [ ] 🛠️ Other (please specify):  

---

### How Has This Been Tested?  
* Tested manually with 5 models from florin as well as 5 models from ourself in 5 atari games in the obs_modes dqn and obj (ours).  Testing script was run_agent.py. 
* I wrote to local tests, where the model_path has to be set and the env have to fit the models. This is an exemplary test to test yourself, not for the CI process (see tests/2_models)

- [x] Unit tests  
- [ ] Integration tests  
- [ ] Manual testing  

---

### Checklist  

- [x] I have reviewed my changes.  
- [x] I have added tests to cover my changes (if applicable).  
- [ ] I have updated the documentation (if applicable).  
- [x] I have followed the project coding style.  
- [x] My changes pass all tests.  

---