### PR TITLE
Add possiblity to render own image

### DIFF
--- a/ocatari/core.py
+++ b/ocatari/core.py
@@ -302,13 +302,16 @@ class OCAtari:
             self.window = pygame.Surface(self.window_size)
         self.rendering_initialized = True
 
-    def render(self):
+    def render(self, image=None):
         """
         Compute the render frames (as specified by render_mode during the initialization of the environment).
         If activated, adds an overlay visualizing object properties like position, velocity vector, name, etc.
         """
         # Render the environment image
-        image = self._env.render()
+
+        if image is None:
+            image = self._env.render()
+
         if not self.render_oc_overlay:
             if self.rendering_initialized:
                 # Upscale and return the rendered image


### PR DESCRIPTION
If users want to render other obs_modes then the original RGB_Screen, this can help.

By setting for example render() to render(env._state_buffer_dqn[-1]) the users can visualize these. 
This however is not compatible with the bounding boxes and similar.

Also this allows removing the unnecessary flickering (blinking) of objects in, e.g., Kangaroo via HackAtari.