### PR TITLE
fix: update Gymnasium installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We are currently supporting versions > 3.9
 
 #### Install Gymnasium with Atari support
 ```sh
-pip install "gymnasium[atari, accept-rom-license]"
+pip install "gymnasium[atari]"
 ```
 
 ### Installation


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file for clarity and accuracy.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R52): Removed the `accept-rom-license` option from the `pip install` command for Gymnasium with Atari support, as it is no longer required.

see release notes
https://gymnasium.farama.org/gymnasium_release_notes/index.html