### PR TITLE
Renames argument parser to restore original references

### DIFF
--- a/ocatari/utils.py
+++ b/ocatari/utils.py
@@ -22,14 +22,14 @@ except ModuleNotFoundError:
     torch_imported = False
 
 
-test_parser = ArgumentParser()
-test_parser.add_argument("-p", "--path", type=str, default=None,
+parser = ArgumentParser()
+parser.add_argument("-p", "--path", type=str, default=None,
                          help="path to the model")
-test_parser.add_argument("-g", "--game", type=str, required=True,
+parser.add_argument("-g", "--game", type=str, required=True,
                          help="game to evaluate (e.g. 'Pong')")
-test_parser.add_argument("-i", "--iou", type=float, default=0.8,
+parser.add_argument("-i", "--iou", type=float, default=0.8,
                          help="Minimum iou for image saving (e.g. 0.7)")
-test_parser.add_argument("-s", "--seed", type=float, default=None,
+parser.add_argument("-s", "--seed", type=float, default=None,
                          help="If provided, set the seed")
 
 

--- a/scripts/testscripts/get_metrics.py
+++ b/scripts/testscripts/get_metrics.py
@@ -14,7 +14,7 @@ from ocatari.vision.tennis import objects_colors
 from ocatari.vision.pong import objects_colors
 from ocatari.vision.bowling import objects_colors
 from ocatari.vision.breakout import objects_colors
-from ocatari.utils import load_agent, test_parser, make_deterministic, RandomAgent
+from ocatari.utils import load_agent, parser, make_deterministic, RandomAgent
 from copy import deepcopy
 import numpy as np
 import os
@@ -35,7 +35,7 @@ import inspect
 figlet = Figlet()
 report_bad = {}
 all_stats = []
-opts = test_parser.parse_args()
+opts = parser.parse_args()
 if opts.seed:
     make_deterministic(opts.seed)
 game_name = opts.game


### PR DESCRIPTION
Replaces `test_parser` with `parser` for restoring imports in scripts. Updates all references to the renamed parser across the codebase to ensure consistency and functionality.

No logic changes were introduced, and the code behavior remains the same.

This pull request refactors the argument parser in `ocatari/utils.py` to improve clarity and reusability. It also updates references to the parser in `scripts/testscripts/get_metrics.py` to align with the naming convention.

The original `parser` argument had been removed in commit cbdd7bcbf9b7e1f7142eb20e22b91ed63662730d, probably in favor of `test_parser`.
Most scripts in `scripts` however still reference the old variable. 
Therefore the new `test_parser` is renamed to `parser`  


### Refactoring of argument parser:

* [`ocatari/utils.py`](diffhunk://#diff-79015a38b5ae9509fe7e7b1b14dd5b8c8fc5910253d51a26fee550c3e664979bL25-R32): Renamed the argument parser from `test_parser` to `parser` for better clarity and consistency.

### Updates to parser references:

* [`scripts/testscripts/get_metrics.py`](diffhunk://#diff-3e6bda9f160d4f6cd3c04da3e8f98e82692354e038ab28ebc551acf71bb7bc07L17-R17): Updated imports and replaced references to `test_parser` with `parser` to reflect the new naming convention. [[1]](diffhunk://#diff-3e6bda9f160d4f6cd3c04da3e8f98e82692354e038ab28ebc551acf71bb7bc07L17-R17) [[2]](diffhunk://#diff-3e6bda9f160d4f6cd3c04da3e8f98e82692354e038ab28ebc551acf71bb7bc07L38-R38)